### PR TITLE
Respect plugin order in config.rb

### DIFF
--- a/lib/middleman-imageoptim/extension.rb
+++ b/lib/middleman-imageoptim/extension.rb
@@ -9,9 +9,14 @@ module Middleman
         options = Middleman::Imageoptim::Options.new(options_hash)
         yield options.user_options if block_given?
 
-        app.after_build {|builder|
-          Middleman::Imageoptim::Optimizer.new(app, builder, options).optimize!
-        }
+        app.after_configuration do
+
+          app.after_build  do |builder|
+            Middleman::Imageoptim::Optimizer.new(app, builder, options).optimize!
+          end
+
+        end
+
       end
       alias :included :registered
     end


### PR DESCRIPTION
after_build should be inside after_config to respect order of plugins in config.rb. Without this images generated by other plugins (such as thumbnailer) don't get optimized because imageoptim is registered before those are run.

There is a similar issue discussed here:
http://forum.middlemanapp.com/t/order-of-after-build-callbacks/901/6
