### PR TITLE
Use spec_helper

### DIFF
--- a/spec/unit/optimizer_spec.rb
+++ b/spec/unit/optimizer_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require_relative "../../lib/middleman-imageoptim/optimizer"
 
 describe Middleman::Imageoptim::Optimizer do

--- a/spec/unit/options_spec.rb
+++ b/spec/unit/options_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require_relative "../../lib/middleman-imageoptim/options"
 
 describe Middleman::Imageoptim::Options do


### PR DESCRIPTION
Specified to require `spec_helper`.
This will fix https://github.com/plasticine/middleman-imageoptim/pull/25. I confirmed all specs are passed.
