### PR TITLE
Compensate for changed require statements in mm

### DIFF
--- a/lib/middleman-imageoptim.rb
+++ b/lib/middleman-imageoptim.rb
@@ -1,4 +1,5 @@
 require 'middleman-core'
+require 'middleman-core/sitemap'
 require 'middleman-imageoptim/optimizer'
 require 'middleman-imageoptim/options'
 require 'middleman-imageoptim/resource_list'


### PR DESCRIPTION
Middleman changed a require statement (https://github.com/middleman/middleman/commit/14104aad70e9431d4891e835474efa7937b396a8) in the 3.3.9 release that leads to the following error

```
...middleman-imageoptim/manifest_resource.rb:3:in `<module:Imageoptim>': uninitialized constant Middleman::Sitemap (NameError)
...
```

This pull request compensates for that change.