### PR TITLE
Update installation instructions, post v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,15 @@ Serving big images is for numb-skulls! Compress and optimise your imagery during
 Go set up the [image_optim](https://github.com/toy/image_optim) external utilities, then;
 
 ### Middleman < 4.0
+
 ```ruby
-gem 'middleman-imageoptim'
+gem 'middleman-imageoptim', '~> 0.2.1'
 ```
 
 ### Middleman ≥ 4.0
 
 ```ruby
-gem "middleman-imageoptim", :git => "https://github.com/plasticine/middleman-imageoptim", :branch => "master"
+gem "middleman-imageoptim", '~> 0.3.0'
 ```
 
 ## Usage


### PR DESCRIPTION
💁 The `0.3.0` version of this gem supports `middleman` 4.x, so updating the relevant documentation to reflect this.