### PR TITLE
Remove support for (deprecated) `:image_optim` extension name

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ end
 
 ##### `0.3.1`
 - Use latest `:image_optim` and `:image_optim_pack` gems.
+- Remove deprecated `:image_optim` extension name.
 
 ##### `0.3.0`
 - https://github.com/plasticine/middleman-imageoptim/compare/v0.2.1...a539cae

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ end
 
 ## Changelog
 
+##### `0.3.1`
+- Use latest `:image_optim` and `:image_optim_pack` gems.
+
 ##### `0.3.0`
 - https://github.com/plasticine/middleman-imageoptim/compare/v0.2.1...a539cae
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ gem 'middleman-imageoptim', '~> 0.2.1'
 ### Middleman ≥ 4.0
 
 ```ruby
-gem "middleman-imageoptim", '~> 0.3.0'
+gem "middleman-imageoptim", '~> 0.4.0'
 ```
 
 ## Usage
@@ -70,7 +70,7 @@ end
 
 ## Changelog
 
-##### `0.3.1`
+##### `0.4.0`
 - Use latest `:image_optim` and `:image_optim_pack` gems.
 - Remove deprecated `:image_optim` extension name.
 

--- a/lib/middleman-imageoptim.rb
+++ b/lib/middleman-imageoptim.rb
@@ -10,10 +10,3 @@ require 'middleman-imageoptim/manifest_resource'
   require 'middleman-imageoptim/extension'
   ::Middleman::Imageoptim::Extension
 end
-
-::Middleman::Extensions.register(:image_optim) do
-  warn ':image_optim is deprecated. Please use `:imageoptim` instead.'
-
-  require 'middleman-imageoptim/extension'
-  ::Middleman::Imageoptim::Extension
-end

--- a/lib/middleman-imageoptim/version.rb
+++ b/lib/middleman-imageoptim/version.rb
@@ -1,6 +1,6 @@
 module Middleman
   module Imageoptim
     PACKAGE = 'middleman-imageoptim'.freeze
-    VERSION = '0.3.0'.freeze
+    VERSION = '0.4.0'.freeze
   end
 end

--- a/middleman-imageoptim.gemspec
+++ b/middleman-imageoptim.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'middleman-core', ['>= 3.1']
   gem.add_dependency 'middleman-cli'
-  gem.add_dependency 'image_optim', '~> 0.25.0'
-  gem.add_dependency 'image_optim_pack', '~> 0.2.1'
+  gem.add_dependency 'image_optim', '~> 0.26'
+  gem.add_dependency 'image_optim_pack', '~> 0.6'
 
   gem.add_development_dependency 'appraisal'
   gem.add_development_dependency 'aruba'


### PR DESCRIPTION
This fixes #49 (and hides the warning)